### PR TITLE
Move immutable as a peerDependencies and update to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "url": "https://github.com/Soreine/immutable-undo/issues"
   },
   "homepage": "https://github.com/Soreine/immutable-undo#readme",
-  "dependencies": {
-    "immutable": "^3.8.1"
+  "peerDependencies": {
+    "immutable": "^3.8.1 | ^4.0.0-rc.12"
   },
   "devDependencies": {
     "babel-cli": "^6.23.1",
@@ -37,6 +37,7 @@
     "eslint": "^3.19.0",
     "eslint-config-gitbook": "^1.5.0",
     "expect": "^1.20.2",
-    "mocha": "^3.0.1"
+    "mocha": "^3.0.1",
+    "immutable": "^4.0.0-rc.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,9 +1553,9 @@ ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
 
-immutable@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
 
 imurmurhash@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
This PR moves `immutable` as a peerDependency and ensure it works with `4.0.0`.

It'd be nice to have CI in this repository (tests are running locally).